### PR TITLE
Fixed alignemnt pattern position array order

### DIFF
--- a/components/qrCode/qrCode.help.brs
+++ b/components/qrCode/qrCode.help.brs
@@ -9,10 +9,10 @@ function _qrCode_help_getAlignmentPatternPositions() as object
     else
         numAlign = floor(m.version / 7) + 2
         stepSize = iif(m.version = 32, 26, ceil((m.version * 4 + 4) / (numAlign * 2 - 2)) * 2)
-        result = [6]
+        result = []
         position = m.size - 7
         while(result.count() < numAlign)
-            splice(result, 1, 0, [position])
+            result.unshift(position)
             position -= stepSize
         end while
         return result

--- a/components/qrCode/qrCode.utils.brs
+++ b/components/qrCode/qrCode.utils.brs
@@ -81,24 +81,6 @@ function concat(array1 as object, array2 as object) as object
     return new
 end function
 
-function splice(array as object, start as integer, delete = 999999 as integer, insert = [] as object)
-    if start > array.count() - 1 then start = array.count() - 1
-    if start < 0 then start = array.count() - start
-    if start < 0 then start = 0
-    if delete < 0 then delete = 0
-    for d = 1 to delete
-        array.delete(start)
-    next
-    tmp = []
-    tmp.append(insert)
-    while(array.count() - 1 > start)
-        tmp.push(array[start])
-        array.delete(start)
-    end while
-    array.append(tmp)
-    return array
-end function
-
 function infinity()
     return 999999
 end function


### PR DESCRIPTION
Wanted to share a fix for QR code generation in case you are open to contributions: 

Fixing an issue where the QR alignment pattern position array is not created in ascending order. When the array is out-of-order, this breaks the array ordering assumption in `qrCode.draw.brs:_qrCode_draw_drawFunctionPatterns` that prevents alignment patterns being generated over finder patterns. This results in the drawn QR code being invalid (for large encoded text size) and not scannable with a QR code scanner. 

qrCode.draw.brs:_qrCode_draw_drawFunctionPatterns: 
```brightscript
  ' Don't draw on the three finder corners
  if (not ((i = 0) and (j = 0) or (i = 0) and (j = numAlign - 1) or (i = numAlign - 1) and (j = 0))) then
      m.drawAlignmentPattern(alignPatPos[i], alignPatPos[j])
  end if
```

Additionally removed the `splice` function since it was not used anywhere else in the code.